### PR TITLE
Adding Gemfile to specify cocoapods version used.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ DerivedData
 #
 .vagrant
 
+#
+# Ruby bundler
+#
+# Note: we currently don't include the Gemfile lock because all we really care about is locking in the Cocoapods version
+#
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: generic
 git:
   submodules: false
 
-env:
-  global:
-     - COCOAPODS_VERSION="1.1.0.rc.2"
-
 matrix:
   include:
     - 
@@ -78,7 +74,8 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then gem install xcpretty -N --no-ri --no-rdoc ; fi
 
-  - if [[ "$BUILD" == "pod lint" ]]; then gem install cocoapods --version "$COCOAPODS_VERSION" --no-document ; fi
+  - if [[ "$BUILD" == "pod lint" ]]; then gem install bundler ; fi
+  - if [[ "$BUILD" == "pod lint" ]]; then bundler install ; fi
 
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -y ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://swift.org/builds/swift-3.0-release/ubuntu1404/swift-3.0-RELEASE/swift-3.0-RELEASE-ubuntu14.04.tar.gz    ; fi
@@ -88,7 +85,7 @@ before_install:
 
 script:
   - if [[ "$BUILD" == "swift build"  ]]; then swift test ; fi
-  - if [[ "$BUILD" == "pod lint"  ]]; then pod lib lint ; fi
+  - if [[ "$BUILD" == "pod lint"  ]]; then bundler exec pod lib lint ; fi
   - if [[ "$BUILD" == "xcodebuild" ]]; then xcodebuild clean test -workspace Example/TraceLog.xcworkspace -scheme "$SCHEME" -destination "$TEST_DEST" -sdk "$TEST_SDK" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty ; fi
 
 after_success:

--- a/Example/TraceLog.xcodeproj/project.pbxproj
+++ b/Example/TraceLog.xcodeproj/project.pbxproj
@@ -95,6 +95,8 @@
 		C6FC67581D386ED7A654BFBA /* Pods-TraceLog-OSX.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TraceLog-OSX.release.xcconfig"; path = "Pods/Target Support Files/Pods-TraceLog-OSX/Pods-TraceLog-OSX.release.xcconfig"; sourceTree = "<group>"; };
 		D063B377EF428F4934F11DFC /* Pods_TraceLog_OSX.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TraceLog_OSX.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DAD59558981C388F77499E21 /* Pods-TraceLog-iOS-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TraceLog-iOS-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TraceLog-iOS-Tests/Pods-TraceLog-iOS-Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		EA1DD02A1DAEDBF5007BEB25 /* Gemfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; name = Gemfile; path = ../Gemfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		EA1DD02B1DAFFA4E007BEB25 /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; name = .gitignore; path = ../.gitignore; sourceTree = "<group>"; };
 		EA1E259A1DA5864100CECAA8 /* EnvironmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnvironmentTests.swift; sourceTree = "<group>"; };
 		EA2FC7ED1DA4538A00902D21 /* codecov.yml */ = {isa = PBXFileReference; lastKnownFileType = text; name = codecov.yml; path = ../codecov.yml; sourceTree = "<group>"; };
 		EA3037F61BEA880300DC4084 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = "TraceLog-iOS/Info.plist"; sourceTree = SOURCE_ROOT; };
@@ -290,6 +292,8 @@
 				EA2FC7ED1DA4538A00902D21 /* codecov.yml */,
 				EA7E7AB51DA0CB8100E3B511 /* Package.swift */,
 				EA7E7AB41DA0C8B800E3B511 /* Vagrantfile */,
+				EA1DD02A1DAEDBF5007BEB25 /* Gemfile */,
+				EA1DD02B1DAFFA4E007BEB25 /* .gitignore */,
 			);
 			name = "Podspec Metadata";
 			sourceTree = "<group>";

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'cocoapods', '~> 1.1.0.rc.2'


### PR DESCRIPTION
Note: this we're currently not adding the Gemfile.lock because we only want to lock down the CocoaPods version required.  Gem file.lock has been added to git ignore so it does not get checked in later.
