### PR TITLE
Split writers and environment

### DIFF
--- a/Sources/TraceLog/Configuration.swift
+++ b/Sources/TraceLog/Configuration.swift
@@ -48,20 +48,16 @@ internal class Configuration {
     init () {}
     
     ///
-    /// (Re)Load this structure with the values for writers and the environment variables
+    /// (Re)Load this structure with the values for the environment variables
     ///
-    func load(_ writers: [Writer], environment: Environment) -> [ConfigurationError] {
+    func load(environment: Environment) -> [ConfigurationError] {
         
         var errors = [ConfigurationError]()
         
         self.globalLogLevel = LogLevel.info
-        
-        self.writers.removeAll()
+    
         self.loggedPrefixes.removeAll()
         self.loggedTags.removeAll()
-
-        /// Initialize the writers first
-        self.writers.append(contentsOf: writers)
         
         for (variable, value) in environment {
             ///

--- a/Sources/TraceLog/Logger.swift
+++ b/Sources/TraceLog/Logger.swift
@@ -149,8 +149,12 @@ internal final class Logger {
 
 #if os(OSX) || os(iOS) || os(tvOS) || os(watchOS)
     
+    /// Internal class exposed to objective-C for low level logging.
     ///
-    /// Internal class exposed to objective-C for low level logging
+    /// - Warning:  This is a private class and nothing in this class should be used on it's own.  Please see TraceLog.h for the public interface to this.
+    ///
+    /// - Note: In order to continue to support Objective-C, this class must be public and also visible to both Swift and ObjC.  This class is not meant to be
+    ///         used directly in either language.
     ///
     @objc(TLLogger)
     public class TLLogger : NSObject {

--- a/Sources/TraceLog/Logger.swift
+++ b/Sources/TraceLog/Logger.swift
@@ -88,10 +88,7 @@ internal final class Logger {
     ///
     /// Configure the logging system with the specified writers and environment
     ///
-    ///  Note: this is a required call if you want to control the log level from ennvironment variables.
-    ///        TraceLog sets itself to the default LogLevel of INFO if this call is not made.
-    ///
-    class func configure(writers: [Writer], environment: Environment) {
+    class func configure(writers: [Writer]? = nil, environment: Environment? = nil) {
         
         ///
         /// Note: we use a synchronous call here for the configuration, all
@@ -99,16 +96,23 @@ internal final class Logger {
         ///
         queue.sync {
         
-            let errors = config.load(writers, environment: environment)
-
-            logPrimitive(level: .info, tag: moduleLogName, file: #file, function: #function, line: #line) {
-                "\(moduleLogName) Configured using: \(config.description)"
+            if let writers = writers {
+                self.config.writers = writers
             }
             
-            for error in errors {
+            if let environment = environment {
                 
-                logPrimitive(level: .warning, tag: moduleLogName, file: #file, function: #function, line: #line) {
-                    "\(error.description)"
+                let errors = config.load(environment: environment)
+                
+                logPrimitive(level: .info, tag: moduleLogName, file: #file, function: #function, line: #line) {
+                    "\(moduleLogName) Configured using: \(config.description)"
+                }
+                
+                for error in errors {
+                    
+                    logPrimitive(level: .warning, tag: moduleLogName, file: #file, function: #function, line: #line) {
+                        "\(error.description)"
+                    }
                 }
             }
         }

--- a/Sources/TraceLog/TraceLog.swift
+++ b/Sources/TraceLog/TraceLog.swift
@@ -38,11 +38,25 @@ import Foundation
 /// ```
 ///
 public
-func configure(writers: [Writer] = [ConsoleWriter()], environment: Environment = Environment()) {
+func configure() {
+    #if !TRACELOG_DISABLED
+        Logger.configure(writers: [ConsoleWriter()], environment: Environment())
+    #endif
+}
+public
+func configure(writers: [Writer]) {
+    #if !TRACELOG_DISABLED
+        Logger.configure(writers: writers, environment: Environment())
+    #endif
+}
+
+public
+func configure(writers: [Writer], environment: Environment) {
     #if !TRACELOG_DISABLED
         Logger.configure(writers: writers, environment: environment)
     #endif
 }
+
 
 ///
 /// logError logs a message with LogLevel Error to the LogWriters

--- a/Tests/TraceLogTests/ConfigurationTests.swift
+++ b/Tests/TraceLogTests/ConfigurationTests.swift
@@ -18,7 +18,7 @@ class ConfigurationTests: XCTestCase {
     func testLoad_Prefixes() {
         let configuration = Configuration()
         
-        let _ = configuration.load([], environment: ["LOG_PREFIX_NS" : "TRACE4"])
+        let _ = configuration.load(environment: ["LOG_PREFIX_NS" : "TRACE4"])
 
         XCTAssertEqual(configuration.loggedPrefixes["NS"], LogLevel.trace4)
     }
@@ -26,7 +26,7 @@ class ConfigurationTests: XCTestCase {
     func testLoad_Tags() {
         let configuration = Configuration()
         
-        let _ = configuration.load([], environment: ["LOG_TAG_TestTag1" : "TRACE4"])
+        let _ = configuration.load(environment: ["LOG_TAG_TestTag1" : "TRACE4"])
         
         XCTAssertEqual(configuration.loggedTags["TestTag1"], LogLevel.trace4)
     }
@@ -40,7 +40,7 @@ class ConfigurationTests: XCTestCase {
     func testLogLevel_All_Set() {
         let configuration = Configuration()
         
-        let _ = configuration.load([], environment: ["LOG_ALL" : "TRACE4"])
+        let _ = configuration.load(environment: ["LOG_ALL" : "TRACE4"])
         
         XCTAssertEqual(configuration.logLevel(for: "AnyString"), LogLevel.trace4)
     }
@@ -48,7 +48,7 @@ class ConfigurationTests: XCTestCase {
     func testLogLevel_Prefix() {
         let configuration = Configuration()
         
-        let _ = configuration.load([], environment: ["LOG_PREFIX_NS" : "TRACE4"])
+        let _ = configuration.load(environment: ["LOG_PREFIX_NS" : "TRACE4"])
         
         XCTAssertEqual(configuration.logLevel(for: "NSString"), LogLevel.trace4)
     }
@@ -56,7 +56,7 @@ class ConfigurationTests: XCTestCase {
     func testLogLevel_Tag() {
         let configuration = Configuration()
         
-        let _ = configuration.load([], environment: ["LOG_TAG_TestTag1" : "TRACE4"])
+        let _ = configuration.load(environment: ["LOG_TAG_TestTag1" : "TRACE4"])
         
         XCTAssertEqual(configuration.logLevel(for: "TestTag1"), LogLevel.trace4)
     }


### PR DESCRIPTION
Change the internal writer and environment loading to be independent.

This was done so that they can be controlled internally independent of each other.  This will allow remote control of the logging levels.

Also, updated documentation for TLLogger with warnings not to use directly.
