### PR TITLE
Fix crash from unexpected String formatters

### DIFF
--- a/Sources/TraceLog/ConsoleWriter.swift
+++ b/Sources/TraceLog/ConsoleWriter.swift
@@ -42,7 +42,7 @@ public class ConsoleWriter: Writer {
         let uppercasedLevel = "\(level)".uppercased()
         let levelString     = "\(String(repeating: " ", count: 7 - uppercasedLevel.characters.count))\(uppercasedLevel)"
         let date            = Date(timeIntervalSince1970: timestamp)
-        let message         = String(format: "\(self.dateFormatter.string(from: date)) \(runtimeContext.processName)[\(runtimeContext.processIdentifier):\(runtimeContext.threadIdentifier)] \(levelString): <\(tag)> \(message)")
+        let message         = "\(self.dateFormatter.string(from: date)) \(runtimeContext.processName)[\(runtimeContext.processIdentifier):\(runtimeContext.threadIdentifier)] \(levelString): <\(tag)> \(message)"
 
         ///
         /// Note: we currently use the calling thread to synchronize knowing that


### PR DESCRIPTION
Remove unnecessary String with formatters call that can result in a crash if the interpolated string includes formatter options that the String(format:) function will never have matching parameters for.
Food for thought: http://stackoverflow.com/questions/29154158/formatting-strings-in-swift