### PR TITLE
Fix default level for `logTrace`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,4 +121,4 @@ script:
     fi
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash) -X fix
+  - bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All significant changes to this project will be documented in this file.
 
+## 4.x.x (Upcoming release)
+
+#### Fixed
+- Fixed `logTrace` when no trace level is passed.  It's now the correct default value of 1 instead of 4 (issue #58).
+
 ## [4.0.1](https://github.com/tonystone/tracelog/tree/4.0.1)
 
 #### Fixed

--- a/Sources/TraceLog/TraceLog.swift
+++ b/Sources/TraceLog/TraceLog.swift
@@ -196,7 +196,7 @@ public func logInfo(_ tag: String? = nil, _ file: String = #file, _ function: St
 ///
 /// - Parameters:
 ///     - tag:     A String to use as a tag to group this call to other calls related to it. If not passed or nil, the file name is used as a tag.
-///     - level    An integer representing the trace LogLevel (i.e. 1, 2, 3, and 4.)
+///     - level    An integer representing the trace LogLevel (i.e. 1, 2, 3, and 4.) If no value is passed, the default trace level is 1.
 ///     - message: An closure or trailing closure that evaluates to the String message to log.
 ///
 /// Examples:
@@ -223,7 +223,7 @@ public func logInfo(_ tag: String? = nil, _ file: String = #file, _ function: St
 ///     }
 /// ```
 ///
-public func logTrace(_ tag: String? = nil, level: Int = LogLevel.trace1.rawValue, _ file: String = #file, _ function: String = #function, _ line: Int = #line, message: @escaping () -> String) {
+public func logTrace(_ tag: String? = nil, level: Int = 1, _ file: String = #file, _ function: String = #function, _ line: Int = #line, message: @escaping () -> String) {
     #if !TRACELOG_DISABLED
         assert(LogLevel.validTraceLevels.contains(level), "Invalid trace level, levels are in the range of \(LogLevel.validTraceLevels)")
 

--- a/Tests/TraceLogTests/TraceLogTests.swift
+++ b/Tests/TraceLogTests/TraceLogTests.swift
@@ -239,7 +239,7 @@ class TraceLogTestsSwift: XCTestCase {
 
         TraceLog.configure(writers: [expectedValues], environment: ["LOG_ALL": "TRACE1"])
 
-        logTrace(testTag, level: 1) { testMessage }
+        logTrace(testTag) { testMessage }
 
         self.waitForExpectations(timeout: 2) { error in
             XCTAssertNil(error)


### PR DESCRIPTION
The `logTrace` method accept an optional level parameter which if not supplied should default to trace level 1.  This PR fixes the default value and corrects the tests so they will properly catch the issue in the future.