### PR TITLE
Switching to Cocoapods 1.6.0.beta.2 so we can compile under xcode 10 …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
          - BUILD="swift build"
     -
       os: osx
-      osx_image: xcode9.3
+      osx_image: xcode10
       env:
          - BUILD="pod lint"
     -
@@ -105,7 +105,6 @@ script:
     if [[ "$BUILD" == "pod lint" ]]; then
         set -e  # Fail (and stop build) on first non zero exit code
         # Currently we can't build using swift 5 under cocoapods.
-        export TOOLCHAINS=
         bundler exec pod lib lint
         set +e
     fi

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
 source 'https://rubygems.org'
-gem 'cocoapods', '~> 1.5.1'
+gem 'cocoapods', '1.6.0.beta.2'


### PR DESCRIPTION
Upgrade to Cocoapods 1.6.0.beta.2 so we can pod lint our podspec.  