### PR TITLE
`Writer' protocol change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All significant changes to this project will be documented in this file.
 - Added `TextFormat`, an implementation of a OutputStreamFormatter that formats its output based on a supplied template (this is the default formatter for Console and File output).
 - Added `JSONFormat`, an implementation of a OutputStreamFormatter that formats its output in standard JSON format.
 - Added `OutputStreamWriter` protocol to define types that write byte streams to their output and accept `OutputStreamFormatter` types to format the output.
+- Added `LogEntry` tuple type to `Writer` defining the formal types that a Writer writes.
 
 #### Changed
 - Required Swift 5 for compilation.
+- Changed `Writer` protocol `log()` method to `write(_ entry: Writer.LogEntry)` to make it easier to process messages by writers and formatters.
 - Changed `ConsoleWriter` to accept new `OutputStreamFormatter` instances allowing you to customize the output log format (default is `TextFormat`.)
 - Changed `FileWriter` to accept new `OutputStreamFormatter` instances allowing you to customize the output log format (default is `TextFormat`.)
 - Changed `FileWriter` archive file name date format to "yyyyMMdd-HHmm-ss-SSS".

--- a/Sources/TraceLog/Formatters/JSONFormat.swift
+++ b/Sources/TraceLog/Formatters/JSONFormat.swift
@@ -116,7 +116,7 @@ public struct JSONFormat: OutputStreamFormatter {
 
     /// Text conversion function required by the `OutputStreamFormatter` protocol.
     ///
-    public func bytes(from timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> [UInt8]? {
+    public func bytes(from entry: Writer.LogEntry) -> [UInt8]? {
         var text = String()
 
         text.write("{\(conditional.newLine)")
@@ -126,16 +126,16 @@ public struct JSONFormat: OutputStreamFormatter {
                 text.write(",\(conditional.newLine)")
             }
             switch attributes[index] {
-                case .timestamp:         self.emit(timestamp,                        forKey: "timestamp", to: &text)
-                case .level:             self.emit(level,                            forKey: "level", to: &text)
-                case .tag:               self.emit(tag,                              forKey: "tag", to: &text)
-                case .message:           self.emit(message,                          forKey: "message", to: &text)
-                case .processName:       self.emit(runtimeContext.processName,       forKey: "processName", to: &text)
-                case .processIdentifier: self.emit(runtimeContext.processIdentifier, forKey: "processIdentifier", to: &text)
-                case .threadIdentifier:  self.emit(runtimeContext.threadIdentifier,  forKey: "threadIdentifier", to: &text)
-                case .file:              self.emit(staticContext.file,               forKey: "file", to: &text)
-                case .function:          self.emit(staticContext.function,           forKey: "function", to: &text)
-                case .line:              self.emit(staticContext.line,               forKey: "line", to: &text)
+                case .timestamp:         self.emit(entry.timestamp,                        forKey: "timestamp", to: &text)
+                case .level:             self.emit(entry.level,                            forKey: "level", to: &text)
+                case .tag:               self.emit(entry.tag,                              forKey: "tag", to: &text)
+                case .message:           self.emit(entry.message,                          forKey: "message", to: &text)
+                case .processName:       self.emit(entry.runtimeContext.processName,       forKey: "processName", to: &text)
+                case .processIdentifier: self.emit(entry.runtimeContext.processIdentifier, forKey: "processIdentifier", to: &text)
+                case .threadIdentifier:  self.emit(entry.runtimeContext.threadIdentifier,  forKey: "threadIdentifier", to: &text)
+                case .file:              self.emit(entry.staticContext.file,               forKey: "file", to: &text)
+                case .function:          self.emit(entry.staticContext.function,           forKey: "function", to: &text)
+                case .line:              self.emit(entry.staticContext.line,               forKey: "line", to: &text)
             }
         }
         text.write("\(conditional.newLine)}")

--- a/Sources/TraceLog/Formatters/OutputStreamFormatter.swift
+++ b/Sources/TraceLog/Formatters/OutputStreamFormatter.swift
@@ -23,8 +23,8 @@ import Foundation
 ///
 public protocol OutputStreamFormatter {
 
-    /// Accepts traceLogs standard parameters and outputs an Array of bytes
+    /// Accepts traceLogs standard LogEntry and outputs an Array of bytes
     /// containing the formatted output.
     ///
-    func bytes(from timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> [UInt8]?
+    func bytes(from entry: Writer.LogEntry) -> [UInt8]?
 }

--- a/Sources/TraceLog/Formatters/TextFormat.swift
+++ b/Sources/TraceLog/Formatters/TextFormat.swift
@@ -277,7 +277,7 @@ public struct TextFormat: OutputStreamFormatter {
 
     /// Text conversion function required by the `OutputStreamFormatter` protocol.
     ///
-    public func bytes(from timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> [UInt8]? {
+    public func bytes(from entry: Writer.LogEntry) -> [UInt8]? {
         var text = String()
 
         /// Write all the elements that have been pre-calculated
@@ -293,17 +293,17 @@ public struct TextFormat: OutputStreamFormatter {
             /// Embed the variables within the constants.
             case .variable(let substitution):
                 switch substitution {
-                case .date:              self.write(Date(timeIntervalSince1970: timestamp), to: &text)
-                case .timestamp:         self.write(timestamp, to: &text)
-                case .level:             self.write(level, to: &text)
-                case .tag:               self.write(tag, to: &text)
-                case .message:           self.write(message, to: &text)
-                case .processName:       self.write(runtimeContext.processName, to: &text)
-                case .processIdentifier: self.write(runtimeContext.processIdentifier, to: &text)
-                case .threadIdentifier:  self.write(runtimeContext.threadIdentifier, to: &text)
-                case .file:              self.write(staticContext.file, to: &text)
-                case .function:          self.write(staticContext.function, to: &text)
-                case .line:              self.write(staticContext.line, to: &text)
+                case .date:              self.write(Date(timeIntervalSince1970: entry.timestamp), to: &text)
+                case .timestamp:         self.write(entry.timestamp, to: &text)
+                case .level:             self.write(entry.level, to: &text)
+                case .tag:               self.write(entry.tag, to: &text)
+                case .message:           self.write(entry.message, to: &text)
+                case .processName:       self.write(entry.runtimeContext.processName, to: &text)
+                case .processIdentifier: self.write(entry.runtimeContext.processIdentifier, to: &text)
+                case .threadIdentifier:  self.write(entry.runtimeContext.threadIdentifier, to: &text)
+                case .file:              self.write(entry.staticContext.file, to: &text)
+                case .function:          self.write(entry.staticContext.function, to: &text)
+                case .line:              self.write(entry.staticContext.line, to: &text)
                 }
             }
         }

--- a/Sources/TraceLog/Logger.swift
+++ b/Sources/TraceLog/Logger.swift
@@ -73,14 +73,13 @@ internal final class Logger {
 
         if localConfig.logLevel(for: tag) >= level {
 
-            let runtimeContext = RuntimeContextImpl()
-            let staticContext  = StaticContextImpl(file: file, function: function, line: line)
-
-            /// Evaluate the message now
-            let messageString = message()
+            /// Evaluate the message and create the LogEntry now that we
+            /// know we are going to output the message.
+            ///
+            let entry: Writer.LogEntry = (timestamp: timestamp, level: level, tag: tag, message: message(), runtimeContext: RuntimeContextImpl(), staticContext: StaticContextImpl(file: file, function: function, line: line))
 
             for writer in localConfig.writers {
-                writer.log(timestamp, level: level, tag: tag, message: messageString, runtimeContext: runtimeContext, staticContext: staticContext)
+                writer.write(entry)
             }
         }
     }

--- a/Sources/TraceLog/Proxies/AsyncWriterProxy.swift
+++ b/Sources/TraceLog/Proxies/AsyncWriterProxy.swift
@@ -38,9 +38,9 @@ internal class AsyncWriterProxy: WriterProxy {
     }
 
     @inline(__always)
-    internal func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    internal func write(_ entry: Writer.LogEntry) {
         queue.async {
-            self.writer.log(timestamp, level: level, tag: tag, message: message, runtimeContext: runtimeContext, staticContext: staticContext)
+            self.writer.write(entry)
         }
     }
 }

--- a/Sources/TraceLog/Proxies/DirectWriterProxy.swift
+++ b/Sources/TraceLog/Proxies/DirectWriterProxy.swift
@@ -33,7 +33,7 @@ internal class DirectWriterProxy: WriterProxy {
     }
 
     @inline(__always)
-    internal func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
-        self.writer.log(timestamp, level: level, tag: tag, message: message, runtimeContext: runtimeContext, staticContext: staticContext)
+    internal func write(_ entry: Writer.LogEntry) {
+        self.writer.write(entry)
     }
 }

--- a/Sources/TraceLog/Proxies/SyncWriterProxy.swift
+++ b/Sources/TraceLog/Proxies/SyncWriterProxy.swift
@@ -38,9 +38,9 @@ internal class SyncWriterProxy: WriterProxy {
     }
 
     @inline(__always)
-    internal func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    internal func write(_ entry: Writer.LogEntry) {
         queue.sync {
-            self.writer.log(timestamp, level: level, tag: tag, message: message, runtimeContext: runtimeContext, staticContext: staticContext)
+            self.writer.write(entry)
         }
     }
 }

--- a/Sources/TraceLog/Proxies/WriterProxy.swift
+++ b/Sources/TraceLog/Proxies/WriterProxy.swift
@@ -21,7 +21,7 @@ import Foundation
 
 internal protocol WriterProxy {
 
-    /// Call to log
+    /// Call to write to the writer.
     ///
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext)
+    func write(_ entry: Writer.LogEntry)
 }

--- a/Sources/TraceLog/Writer.swift
+++ b/Sources/TraceLog/Writer.swift
@@ -35,8 +35,7 @@ import Swift
 ///
 public protocol Writer {
 
-    ///
-    /// Called when the logger needs to log an event to this logger.
+    ///  Log Entry represents an element that can be written by a Writer.
     ///
     /// - Parameters:
     ///     - timestamp:             Timestamp of the log event (number of seconds from 1970).
@@ -51,5 +50,14 @@ public protocol Writer {
     /// - SeeAlso: RuntimeContext
     /// - SeeAlso: StaticContext
     ///
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext)
+    typealias LogEntry = (timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext)
+
+    ///
+    /// Called when the logger needs to log an event to this logger.
+    ///
+    /// - Parameter entry: A LogEntry type to write to the output.
+    ///
+    /// - SeeAlso: LogEntry
+    ///
+    func write(_ entry: LogEntry)
 }

--- a/Sources/TraceLog/Writers/ConsoleWriter.swift
+++ b/Sources/TraceLog/Writers/ConsoleWriter.swift
@@ -52,9 +52,9 @@ public class ConsoleWriter: OutputStreamWriter {
     ///
     /// Required log function for the logger
     ///
-    public func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    public func write(_ entry: Writer.LogEntry) {
 
-        guard let bytes = format.bytes(from: timestamp, level: level, tag: tag, message: message, runtimeContext: runtimeContext, staticContext: staticContext)
+        guard let bytes = format.bytes(from: entry)
             else { return }
 
         ///

--- a/Sources/TraceLog/Writers/FileWriter.swift
+++ b/Sources/TraceLog/Writers/FileWriter.swift
@@ -106,9 +106,9 @@ public class FileWriter: OutputStreamWriter {
 
     /// Required log function for the logger
     ///
-    public func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    public func write(_ entry: Writer.LogEntry) {
 
-        guard let bytes = format.bytes(from: timestamp, level: level, tag: tag, message: message, runtimeContext: runtimeContext, staticContext: staticContext)
+        guard let bytes = format.bytes(from: entry)
             else { return }
 
         /// Note: Since we could be called on any thread in TraceLog direct mode

--- a/Sources/TraceLogTestHarness/BufferReader.swift
+++ b/Sources/TraceLogTestHarness/BufferReader.swift
@@ -28,12 +28,12 @@ public class BufferReader: Reader {
     ///
     public init() {}
 
-    public func logEntry(for writer: BufferWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> LogEntry? {
+    public func logEntry(for writer: BufferWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> TestLogEntry? {
 
         guard let logEntry = writer.buffer[message]
             else { return nil }
 
-        return LogEntry(timestamp: logEntry.timestamp,
+        return TestLogEntry(timestamp: logEntry.timestamp,
                             level: logEntry.level,
                           message: logEntry.message,
                               tag: logEntry.tag,

--- a/Sources/TraceLogTestHarness/BufferWriter.swift
+++ b/Sources/TraceLogTestHarness/BufferWriter.swift
@@ -27,7 +27,7 @@ public class BufferWriter: Writer {
     ///
     /// A buffer to hold the values written to this writer.
     ///
-    public var buffer: [String: (timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext)] = [:]
+    public var buffer: [String: Writer.LogEntry] = [:]
 
     /// Initialize an instance of `self` to its initial empty state.
     ///
@@ -36,7 +36,7 @@ public class BufferWriter: Writer {
     ///
     /// Required log function for the `Writer`.
     ///
-    public func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
-        self.buffer[message] = (timestamp, level, tag, message, runtimeContext, staticContext)
+    public func write(_ entry: Writer.LogEntry) {
+        self.buffer[entry.message] = entry
     }
 }

--- a/Tests/TraceLogTestHarnessTests/TestHarnessTests.swift
+++ b/Tests/TraceLogTestHarnessTests/TestHarnessTests.swift
@@ -22,7 +22,7 @@ import TraceLog
 
 @testable import TraceLogTestHarness
 
-private let testEqual: (BufferWriter, LogEntry?, LogEntry) -> Void = { writer, result, expected in
+private let testEqual: (BufferWriter, TestLogEntry?, TestLogEntry) -> Void = { writer, result, expected in
 
     guard let result = result
         else { XCTFail("Failed to locate log entry."); return }

--- a/Tests/TraceLogTests/Formatters/JSONFormatTests.swift
+++ b/Tests/TraceLogTests/Formatters/JSONFormatTests.swift
@@ -90,9 +90,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeTimestamp() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.timestamp], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"timestamp\":28800.0}")
@@ -102,9 +103,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeTimestampPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.timestamp], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"timestamp\" : 28800.0\n}")
@@ -115,9 +117,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeLevel() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.level], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"level\":\"INFO\"}")
@@ -127,9 +130,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeLevelPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.level], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"level\" : \"INFO\"\n}")
@@ -140,9 +144,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeTag() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.tag], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"tag\":\"TestTag\"}")
@@ -152,9 +157,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeTagPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.tag], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"tag\" : \"TestTag\"\n}")
@@ -165,9 +171,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.message], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"message\":\"Test message.\"}")
@@ -177,9 +184,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeMessagePrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.message], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"message\" : \"Test message.\"\n}")
@@ -190,9 +198,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeProcessName() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processName], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processName\":\"TestProcess\"}")
@@ -202,9 +211,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeProcessNamePrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processName], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processName\" : \"TestProcess\"\n}")
@@ -215,9 +225,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeProcessIdentifier() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processIdentifier\":120}")
@@ -227,9 +238,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeProcessIdentifierPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processIdentifier\" : 120\n}")
@@ -240,9 +252,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeThreadIdentifier() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processIdentifier\":120}")
@@ -252,9 +265,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeThreadIdentifierPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processIdentifier\" : 120\n}")
@@ -265,9 +279,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeFile() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
         let format = JSONFormat(attributes: [.file], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"file\":\"JSONFormat.swift\"}")
@@ -277,9 +292,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeFilePrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
         let format = JSONFormat(attributes: [.file], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"file\" : \"JSONFormat.swift\"\n}")
@@ -290,9 +306,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeFunction() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
         let format = JSONFormat(attributes: [.function], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"function\":\"testAttributeFunction()\"}")
@@ -302,9 +319,10 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeFunctionPrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
         let format = JSONFormat(attributes: [.function], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"function\" : \"testAttributeFunction()\"\n}")
@@ -315,9 +333,10 @@ class JSONFormatTests: XCTestCase {
     /// Test that you can specify the individual attribute for output.
     ///
     func testAttributeLine() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
         let format = JSONFormat(attributes: [.line], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"line\":240}")
@@ -327,18 +346,20 @@ class JSONFormatTests: XCTestCase {
     /// for output (printed with formatting characters).
     ///
     func testAttributeLinePrettyPrint() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
         let format = JSONFormat(attributes: [.line], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"line\" : 240\n}")
     }
 
     func testAttributeDefaultList() throws {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
         let format = JSONFormat(terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         guard let json = try JSONSerialization.jsonObject(with: Data(bytes), options: []) as? [String: Any]
@@ -358,9 +379,10 @@ class JSONFormatTests: XCTestCase {
     }
 
     func testAttributeDefaultListWithPrettyPrinting() throws {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
         let format = JSONFormat( options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         guard let json = try JSONSerialization.jsonObject(with: Data(bytes), options: []) as? [String: Any]
@@ -385,9 +407,10 @@ class JSONFormatTests: XCTestCase {
     /// gets written to the output.
     ///
     func testTerminatorCanBeSet() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let format = JSONFormat(attributes: [.message], terminator: ",\n\t")
 
-        guard let bytes =  format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        guard let bytes =  format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"message\":\"Simple message.\"},\n\t")

--- a/Tests/TraceLogTests/Formatters/TextFormat+EncodingTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormat+EncodingTests.swift
@@ -30,13 +30,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testAsciiEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .ascii, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".ascii\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .ascii), "Simple Ascii text.",
-            "Failed conversion to \".ascii\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .ascii), expected, "Failed conversion to \".ascii\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.iso2022JP`.
@@ -44,13 +46,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testIso2022JpEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .iso2022JP, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".iso2022JP\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .iso2022JP), "Simple Ascii text.",
-            "Failed conversion to \".iso2022JP\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .iso2022JP), expected, "Failed conversion to \".iso2022JP\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.isoLatin1`.
@@ -58,13 +62,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testIsolatin1EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .isoLatin1, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin1\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin1), "Simple Ascii text.",
-            "Failed conversion to \".isoLatin1\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin1), expected, "Failed conversion to \".isoLatin1\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.isoLatin2`.
@@ -72,13 +78,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testIsolatin2EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .isoLatin2, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin2\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin2), "Simple Ascii text.",
-            "Failed conversion to \".isoLatin2\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin2), expected, "Failed conversion to \".isoLatin2\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.macOSRoman`.
@@ -86,13 +94,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testMacosromanEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .macOSRoman, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".macOSRoman\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .macOSRoman), "Simple Ascii text.",
-            "Failed conversion to \".macOSRoman\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .macOSRoman), expected, "Failed conversion to \".macOSRoman\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.nextstep`.
@@ -100,13 +110,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testNextstepEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .nextstep, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".nextstep\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .nextstep), "Simple Ascii text.",
-            "Failed conversion to \".nextstep\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .nextstep), expected, "Failed conversion to \".nextstep\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.nonLossyASCII`.
@@ -114,13 +126,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testNonlossyasciiEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .nonLossyASCII, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".nonLossyASCII\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .nonLossyASCII), "Simple Ascii text.",
-            "Failed conversion to \".nonLossyASCII\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .nonLossyASCII), expected, "Failed conversion to \".nonLossyASCII\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.shiftJIS`.
@@ -128,13 +142,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testShiftjisEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .shiftJIS, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".shiftJIS\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .shiftJIS), "Simple Ascii text.",
-            "Failed conversion to \".shiftJIS\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .shiftJIS), expected, "Failed conversion to \".shiftJIS\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.unicode`.
@@ -142,13 +158,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUnicodeEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .unicode, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".unicode\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .unicode), "Simple Ascii text.",
-            "Failed conversion to \".unicode\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .unicode), expected, "Failed conversion to \".unicode\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf16`.
@@ -156,13 +174,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf16EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf16), "Simple Ascii text.",
-            "Failed conversion to \".utf16\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf16), expected, "Failed conversion to \".utf16\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf16BigEndian`.
@@ -170,13 +190,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf16BigendianEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16BigEndian\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf16BigEndian), "Simple Ascii text.",
-            "Failed conversion to \".utf16BigEndian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf16BigEndian), expected, "Failed conversion to \".utf16BigEndian\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf16LittleEndian`.
@@ -184,13 +206,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf16LittleendianEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16LittleEndian\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf16LittleEndian), "Simple Ascii text.",
-            "Failed conversion to \".utf16LittleEndian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf16LittleEndian), expected, "Failed conversion to \".utf16LittleEndian\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf32`.
@@ -198,13 +222,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf32EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf32), "Simple Ascii text.",
-            "Failed conversion to \".utf32\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf32), expected, "Failed conversion to \".utf32\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf32BigEndian`.
@@ -212,13 +238,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf32BigendianEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32BigEndian\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf32BigEndian), "Simple Ascii text.",
-            "Failed conversion to \".utf32BigEndian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf32BigEndian), expected, "Failed conversion to \".utf32BigEndian\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf32LittleEndian`.
@@ -226,13 +254,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf32LittleendianEncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32LittleEndian\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf32LittleEndian), "Simple Ascii text.",
-            "Failed conversion to \".utf32LittleEndian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf32LittleEndian), expected, "Failed conversion to \".utf32LittleEndian\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.utf8`.
@@ -240,13 +270,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testUtf8EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf8\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Simple Ascii text.",
-            "Failed conversion to \".utf8\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion to \".utf8\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.windowsCP1250`.
@@ -254,13 +286,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testWindowscp1250EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1250, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1250\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1250), "Simple Ascii text.",
-            "Failed conversion to \".windowsCP1250\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1250), expected, "Failed conversion to \".windowsCP1250\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.windowsCP1251`.
@@ -268,13 +302,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testWindowscp1251EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1251, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1251\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1251), "Simple Ascii text.",
-            "Failed conversion to \".windowsCP1251\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1251), expected, "Failed conversion to \".windowsCP1251\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.windowsCP1252`.
@@ -282,13 +318,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testWindowscp1252EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1252, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1252\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1252), "Simple Ascii text.",
-            "Failed conversion to \".windowsCP1252\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1252), expected, "Failed conversion to \".windowsCP1252\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.windowsCP1253`.
@@ -296,13 +334,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testWindowscp1253EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1253, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1253\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1253), "Simple Ascii text.",
-            "Failed conversion to \".windowsCP1253\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1253), expected, "Failed conversion to \".windowsCP1253\".")
     }
 
     /// Test that we can encode a simple Ascii message to `String.Encoding.windowsCP1254`.
@@ -310,13 +350,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using just Ascii characters in the messages.
     ///
     func testWindowscp1254EncodingWithSimpleAsciiMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Simple Ascii text."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1254, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1254\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1254), "Simple Ascii text.",
-            "Failed conversion to \".windowsCP1254\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1254), expected, "Failed conversion to \".windowsCP1254\".")
     }
 
 
@@ -325,14 +367,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testAsciiEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .ascii, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .ascii)
             else { XCTFail("Failed to convert log entry to encoding \".ascii\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".ascii\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".ascii\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.iso2022JP`.
@@ -340,14 +384,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testIso2022JpEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .iso2022JP, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .iso2022JP)
             else { XCTFail("Failed to convert log entry to encoding \".iso2022JP\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".iso2022JP\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".iso2022JP\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.isoLatin1`.
@@ -355,14 +401,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testIsolatin1EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .isoLatin1, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .isoLatin1)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin1\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".isoLatin1\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".isoLatin1\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.isoLatin2`.
@@ -370,14 +418,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testIsolatin2EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .isoLatin2, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .isoLatin2)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin2\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".isoLatin2\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".isoLatin2\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.macOSRoman`.
@@ -385,14 +435,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testMacosromanEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .macOSRoman, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .macOSRoman)
             else { XCTFail("Failed to convert log entry to encoding \".macOSRoman\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".macOSRoman\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".macOSRoman\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.nextstep`.
@@ -400,14 +452,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testNextstepEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .nextstep, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .nextstep)
             else { XCTFail("Failed to convert log entry to encoding \".nextstep\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".nextstep\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".nextstep\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.nonLossyASCII`.
@@ -415,14 +469,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testNonlossyasciiEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .nonLossyASCII, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .nonLossyASCII)
             else { XCTFail("Failed to convert log entry to encoding \".nonLossyASCII\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".nonLossyASCII\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".nonLossyASCII\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.shiftJIS`.
@@ -430,14 +486,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testShiftjisEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .shiftJIS, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .shiftJIS)
             else { XCTFail("Failed to convert log entry to encoding \".shiftJIS\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".shiftJIS\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".shiftJIS\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.unicode`.
@@ -445,14 +503,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUnicodeEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .unicode, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .unicode)
             else { XCTFail("Failed to convert log entry to encoding \".unicode\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".unicode\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".unicode\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf16`.
@@ -460,14 +520,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf16EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16)
             else { XCTFail("Failed to convert log entry to encoding \".utf16\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf16\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf16\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf16BigEndian`.
@@ -475,14 +537,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf16BigendianEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16BigEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf16BigEndian\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf16BigEndian\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf16BigEndian\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf16LittleEndian`.
@@ -490,14 +554,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf16LittleendianEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf16LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16LittleEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf16LittleEndian\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf16LittleEndian\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf16LittleEndian\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf32`.
@@ -505,14 +571,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf32EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32)
             else { XCTFail("Failed to convert log entry to encoding \".utf32\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf32\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf32\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf32BigEndian`.
@@ -520,14 +588,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf32BigendianEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32BigEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf32BigEndian\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf32BigEndian\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf32BigEndian\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf32LittleEndian`.
@@ -535,14 +605,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "NON-LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf32LittleendianEncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf32LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32LittleEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf32LittleEndian\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf32LittleEndian\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf32LittleEndian\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.utf8`.
@@ -550,14 +622,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testUtf8EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf8)
             else { XCTFail("Failed to convert log entry to encoding \".utf8\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".utf8\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".utf8\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.windowsCP1250`.
@@ -565,14 +639,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testWindowscp1250EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1250, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1250)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1250\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".windowsCP1250\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".windowsCP1250\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.windowsCP1251`.
@@ -580,14 +656,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testWindowscp1251EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1251, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1251)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1251\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".windowsCP1251\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".windowsCP1251\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.windowsCP1252`.
@@ -595,14 +673,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testWindowscp1252EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1252, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1252)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1252\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".windowsCP1252\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".windowsCP1252\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.windowsCP1253`.
@@ -610,14 +690,16 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testWindowscp1253EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1253, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1253)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1253\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".windowsCP1253\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".windowsCP1253\".")
     }
 
     /// Test that we can encode a Unicode message to `String.Encoding.windowsCP1254`.
@@ -625,13 +707,15 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     /// Note: This will be a "LOSSY" operation when using Unicode characters in the messages.
     ///
     func testWindowscp1254EncodingWithUnicodeMessage() {
+        let entry: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}."
+
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1254, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
+        guard let bytes = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1254)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1254\""); return }
 
-        XCTAssertTrue(result.range(of: "Print a few unicode characters \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}, \\?{1,4}.", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".windowsCP1254\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".windowsCP1254\".")
     }
 }

--- a/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift
@@ -33,154 +33,196 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
     /// Test that we can encode a "Danish (da)" message.
     ///
     func testBytesWithDanishMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Wolther spillede på xylofon.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Wolther spillede på xylofon."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Wolther spillede på xylofon.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Danish language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen Wolther spillede på xylofon.", "Failed conversion for \"Danish\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Danish\".")
     }
 
     /// Test that we can encode a "German (de)" message.
     ///
     func testBytesWithGermanMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the German language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Falsches Üben von Xylophonmusik quält jeden größeren Zwerg", "Failed conversion for \"German\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"German\".")
     }
 
     /// Test that we can encode a "Greek (el)" message.
     ///
     func testBytesWithGreekMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Greek language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο", "Failed conversion for \"Greek\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Greek\".")
     }
 
     /// Test that we can encode a "English (en)" message.
     ///
     func testBytesWithEnglishMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "The quick brown fox jumps over the lazy dog", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "The quick brown fox jumps over the lazy dog"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "The quick brown fox jumps over the lazy dog", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the English language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "The quick brown fox jumps over the lazy dog", "Failed conversion for \"English\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"English\".")
     }
 
     /// Test that we can encode a "Spanish (es)" message.
     ///
     func testBytesWithSpanishMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Spanish language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y frío, añoraba a su querido cachorro.", "Failed conversion for \"Spanish\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Spanish\".")
     }
 
     /// Test that we can encode a "French (fr)" message.
     ///
     func testBytesWithFrenchMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogenèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogenèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogenèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the French language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogenèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.", "Failed conversion for \"French\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"French\".")
     }
 
     /// Test that we can encode a "IrishGaelic (ga)" message.
     ///
     func testBytesWithIrishGaelicMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the IrishGaelic language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh", "Failed conversion for \"IrishGaelic\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"IrishGaelic\".")
     }
 
     /// Test that we can encode a "Hungarian (hu)" message.
     ///
     func testBytesWithHungarianMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Árvíztűrő tükörfúrógép", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Árvíztűrő tükörfúrógép"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Árvíztűrő tükörfúrógép", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Hungarian language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Árvíztűrő tükörfúrógép", "Failed conversion for \"Hungarian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Hungarian\".")
     }
 
     /// Test that we can encode a "Icelandic (is)" message.
     ///
     func testBytesWithIcelandicMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Icelandic language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa", "Failed conversion for \"Icelandic\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Icelandic\".")
     }
 
     /// Test that we can encode a "Japanese (jp, )" message.
     ///
     func testBytesWithJapaneseMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "いろはにほへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "いろはにほへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "いろはにほへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Japanese language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "いろはにほへとちりぬるをわかよたれそつねならむうゐのおくやまけふこえてあさきゆめみしゑひもせす", "Failed conversion for \"Japanese\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Japanese\".")
     }
 
     /// Test that we can encode a "Katakana ()" message.
     ///
     func testBytesWithKatakanaMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Katakana language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン", "Failed conversion for \"Katakana\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Katakana\".")
     }
 
     /// Test that we can encode a "Polish (pl)" message.
     ///
     func testBytesWithPolishMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Pchnąć w tę łódź jeża lub ośm skrzyń fig", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Pchnąć w tę łódź jeża lub ośm skrzyń fig"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Pchnąć w tę łódź jeża lub ośm skrzyń fig", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Polish language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Pchnąć w tę łódź jeża lub ośm skrzyń fig", "Failed conversion for \"Polish\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Polish\".")
     }
 
     /// Test that we can encode a "Russian (ru)" message.
     ///
     func testBytesWithRussianMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "чащах юга жил бы цитрус? Да, но фальшивый экземпляр!", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "чащах юга жил бы цитрус? Да, но фальшивый экземпляр!"
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "чащах юга жил бы цитрус? Да, но фальшивый экземпляр!", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Russian language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "чащах юга жил бы цитрус? Да, но фальшивый экземпляр!", "Failed conversion for \"Russian\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Russian\".")
     }
 
     /// Test that we can encode a "Turkish (tr)" message.
     ///
     func testBytesWithTurkishMessage() {
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Pijamalı hasta, yağız şoföre çabucak güvendi.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "Pijamalı hasta, yağız şoföre çabucak güvendi."
+
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Pijamalı hasta, yağız şoföre çabucak güvendi.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Turkish language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Pijamalı hasta, yağız şoföre çabucak güvendi.", "Failed conversion for \"Turkish\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Turkish\".")
     }
 }

--- a/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift.gyb
+++ b/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift.gyb
@@ -54,10 +54,13 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
     func testBytesWith${Language}Message() {
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "${Text}", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "${Text}", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "${Text}"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the ${Language} language."); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "${Text}", "Failed conversion for \"${Language}\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"${Language}\".")
     }
 % end
 }

--- a/Tests/TraceLogTests/Formatters/TextFormatTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormatTests.swift
@@ -137,24 +137,28 @@ class TextFormatTests: XCTestCase {
     ///
     func testTemplateDate() {
         let format = TextFormat(template: "%{date}", terminator: "")
-        let timestamp = 28800.0
 
-        guard let bytes = format.bytes(from: timestamp, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: timestamp)))
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
     ///
     func testTemplateMultipleDate() {
         let format = TextFormat(template: "%{date}%{date}%{date}", terminator: "")
-        let timestamp = 28800.0
 
-        guard let bytes = format.bytes(from: timestamp, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = String(repeating: TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp)), count: 3)
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), String(repeating: TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: timestamp)), count: 3))
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{timestamp}
@@ -164,10 +168,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateTimestamp() {
         let format = TextFormat(template: "%{timestamp}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "28800.0"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "28800.0")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -175,10 +182,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleTimestamp() {
         let format = TextFormat(template: "%{timestamp}%{timestamp}%{timestamp}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "28800.028800.028800.0"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "28800.028800.028800.0")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{level}
@@ -188,10 +198,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateLevel() {
         let format = TextFormat(template: "%{level}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "INFO"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "INFO")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -199,10 +212,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleLevel() {
         let format = TextFormat(template: "%{level}%{level}%{level}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "INFOINFOINFO"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "INFOINFOINFO")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{tag}
@@ -212,10 +228,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateTag() {
         let format = TextFormat(template: "%{tag}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "TestTag"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "TestTag")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -223,10 +242,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleTag() {
         let format = TextFormat(template: "%{tag}%{tag}%{tag}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "TestTagTestTagTestTag"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "TestTagTestTagTestTag")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{message}
@@ -236,10 +258,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMessage() {
         let format = TextFormat(template: "%{message}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "Test message."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Test message.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -247,10 +272,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleMessage() {
         let format = TextFormat(template: "%{message}%{message}%{message}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "Test message.Test message.Test message."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Test message.Test message.Test message.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{processName}
@@ -260,10 +288,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateProcessName() {
         let format = TextFormat(template: "%{processName}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
+        let expected: String       = "Test Process"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Test Process")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -271,10 +302,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleProcessName() {
         let format = TextFormat(template: "%{processName}%{processName}%{processName}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
+        let expected: String       = "Test ProcessTest ProcessTest Process"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Test ProcessTest ProcessTest Process")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{processIdentifier}
@@ -284,10 +318,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateProcessIdentifier() {
         let format = TextFormat(template: "%{processIdentifier}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
+        let expected: String       = "500"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "500")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -295,10 +332,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleProcessIdentifier() {
         let format = TextFormat(template: "%{processIdentifier}%{processIdentifier}%{processIdentifier}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
+        let expected: String       = "500500500"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "500500500")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{threadIdentifier}
@@ -308,10 +348,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateThreadIdentifier() {
         let format = TextFormat(template: "%{threadIdentifier}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
+        let expected: String       = "200"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "200")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -319,10 +362,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleThreadIdentifier() {
         let format = TextFormat(template: "%{threadIdentifier}%{threadIdentifier}%{threadIdentifier}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
+        let expected: String       = "200200200"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "200200200")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{file}
@@ -332,10 +378,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateFile() {
         let format = TextFormat(template: "%{file}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
+        let expected: String       = "TextFormatTests.swift"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "TextFormatTests.swift")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -343,10 +392,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleFile() {
         let format = TextFormat(template: "%{file}%{file}%{file}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
+        let expected: String       = "TextFormatTests.swiftTextFormatTests.swiftTextFormatTests.swift"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "TextFormatTests.swiftTextFormatTests.swiftTextFormatTests.swift")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{function}
@@ -356,10 +408,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateFunction() {
         let format = TextFormat(template: "%{function}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
+        let expected: String       = "testTemplateFunction()"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "testTemplateFunction()")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -367,10 +422,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleFunction() {
         let format = TextFormat(template: "%{function}%{function}%{function}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
+        let expected: String       = "testTemplateFunction()testTemplateFunction()testTemplateFunction()"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "testTemplateFunction()testTemplateFunction()testTemplateFunction()")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Substitution: %{line}
@@ -380,10 +438,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateLine() {
         let format = TextFormat(template: "%{line}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "120"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "120")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that you can specify the substitution parameter multiple times.
@@ -391,22 +452,27 @@ class TextFormatTests: XCTestCase {
     func testTemplateMultipleLine() {
         let format = TextFormat(template: "%{line}%{line}%{line}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "120120120"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "120120120")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that the default template produces the correct message output.
     ///
     func testTemplateDefault() {
         let format = TextFormat(terminator: "")
-        let timestamp = 28800.0
 
-        guard let bytes = format.bytes(from: timestamp, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
+        let expected: String       = "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))) TestProcess[100:1100] INFO: <TestTag> Test message."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: timestamp))) TestProcess[100:1100] INFO: <TestTag> Test message.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that a template containing all the variables
@@ -414,24 +480,28 @@ class TextFormatTests: XCTestCase {
     ///
     func testTemplateWithAllVariables() {
         let format = TextFormat(template: "%{date} %{timestamp} %{processName}[%{processIdentifier}:%{threadIdentifier}] %{level}: <%{tag}> [%{file}:%{function}:%{line}] %{message}", terminator: "")
-        let timestamp = 28800.0
 
-        guard let bytes = format.bytes(from: timestamp, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let expected: String       = "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))) \(input.timestamp) TestProcess[50:200] WARNING: <TestTag> [TextFormatTests.swift:testTemplateWithAllVariables():306] Test message."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: timestamp))) \(timestamp) TestProcess[50:200] WARNING: <TestTag> [TextFormatTests.swift:testTemplateWithAllVariables():306] Test message.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that a template containing a tab delimited form.
     ///
     func testTemplateWithTabDelimited() {
         let format = TextFormat(template: "\"%{date}\", \"%{processName}\", %{processIdentifier}, %{threadIdentifier}, \"%{level}\", \"%{tag}\", \"%{message}\"", terminator: "\n")
-        let timestamp = 28800.0
 
-        guard let bytes = format.bytes(from: timestamp, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let expected: String       = "\"\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp)))\", \"TestProcess\", 50, 200, \"WARNING\", \"TestTag\", \"Test message.\"\n"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "\"\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: timestamp)))\", \"TestProcess\", 50, 200, \"WARNING\", \"TestTag\", \"Test message.\"\n")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that all template constants are passed through
@@ -440,10 +510,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateConstantsArePassedThrough() {
         let format = TextFormat(template: "~!@#$%^&*()%{level}1234567890%{tag}abcdefghijklmnop", terminator: "")
 
-        guard let bytes = format.bytes(from: 1.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let input: Writer.LogEntry = (timestamp: 1.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
+        let expected: String       = "~!@#$%^&*()WARNING1234567890TestTagabcdefghijklmnop"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "~!@#$%^&*()WARNING1234567890TestTagabcdefghijklmnop")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
 
@@ -452,12 +525,15 @@ class TextFormatTests: XCTestCase {
     /// Test that a random constant value will be printed as a constant.
     ///
     func testTemplateAllConstants() {
-        let format = TextFormat(template: "{}} This is a constant string that will be output %{(0001234 with specifal characters.", terminator: "")
+        let format = TextFormat(template: "{}} This is a constant string that will be output %{(0001234 with special characters}.", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "{}} This is a constant string that will be output %{(0001234 with special characters}."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{}} This is a constant string that will be output %{(0001234 with specifal characters.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that any combination of %{} that is not a valid substitution variable
@@ -466,10 +542,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateIncorrectVariables() {
         let format = TextFormat(template: "%{This} %{is} %{a} %{constant} %{string} %{that} %{will} %{be} %{output}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "%{This} %{is} %{a} %{constant} %{string} %{that} %{will} %{be} %{output}"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "%{This} %{is} %{a} %{constant} %{string} %{that} %{will} %{be} %{output}")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that a double %{} wrapped valid variable prints correctly.
@@ -477,10 +556,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateDoubleWrappedVariable() {
         let format = TextFormat(template: "%{%{level}}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "%{INFO}"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "%{INFO}")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test a message with embedded variables does not substitute the embedded variables.
@@ -488,10 +570,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMessageWithEmbeddedVaraibles() {
         let format = TextFormat(template: "%{level} %{message}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "INFO %{level}"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "INFO %{level}")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test a message with embedded variables does not substitute the embedded variables.
@@ -499,10 +584,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMessageWithEmbeddedVaraiblesReversed() {
         let format = TextFormat(template: "%{message} %{level}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "%{level} INFO"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "%{level} INFO")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test a message with embedded message variables does not substitute the embedded variables.
@@ -510,10 +598,13 @@ class TextFormatTests: XCTestCase {
     func testTemplateMessageWithEmbeddedMessageVariable() {
         let format = TextFormat(template: "%{message}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "%{message} check", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{message} check", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "%{message} check"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "%{message} check")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     // MARK: - Test .controlCharacters
@@ -525,10 +616,13 @@ class TextFormatTests: XCTestCase {
     func testControlCharactersStripActuallyStrips() {
         let format = TextFormat(template: "%{message}", options: [.controlCharacters(.strip)], terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "This message contains multiple lines and control characters."
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "This message contains multiple lines and control characters.")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that by passing options: [.controlCharacters(.escape)],
@@ -538,10 +632,13 @@ class TextFormatTests: XCTestCase {
     func testControlCharactersEscapeActuallyEscapes() {
         let format = TextFormat(template: "%{message}", options: [.controlCharacters(.escape)], terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "\\tThis message contains multiple \\nlines and \\tcontrol characters.\\n"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "\\tThis message contains multiple \\nlines and \\tcontrol characters.\\n")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     /// Test that by not passing options: [.controlCharacters(.strip)],
@@ -551,10 +648,13 @@ class TextFormatTests: XCTestCase {
     func testControlCharactersAbsentLeavesTheCharacters() {
         let format = TextFormat(template: "%{message}", terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "\tThis message contains multiple \nlines and \tcontrol characters.\n"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "\tThis message contains multiple \nlines and \tcontrol characters.\n")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 
     // MARK: - Test terminator
@@ -565,9 +665,12 @@ class TextFormatTests: XCTestCase {
     func testTerminatorCanBeSet() {
         let format = TextFormat(template: "%{message}", options: [.controlCharacters(.strip)], terminator: ",\n\t")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
+        let expected: String       = "Simple message.,\n\t"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail(); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "Simple message.,\n\t")
+        XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
 }

--- a/Tests/TraceLogTests/Formatters/Textformat+EncodingTests.swift.gyb
+++ b/Tests/TraceLogTests/Formatters/Textformat+EncodingTests.swift.gyb
@@ -86,11 +86,13 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     func test${Encoding.title()}EncodingWithSimpleAsciiMessage() {
         let format = TextFormat(template: "%{message}", encoding: .${Encoding}, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple Ascii text.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "${Expected}"
+
+        guard let bytes = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".${Encoding}\""); return }
 
-        XCTAssertEqual(String(bytes: bytes, encoding: .${Encoding}), "${Expected}",
-            "Failed conversion to \".${Encoding}\".")
+        XCTAssertEqual(String(bytes: bytes, encoding: .${Encoding}), expected, "Failed conversion to \".${Encoding}\".")
     }
 % end
 
@@ -103,12 +105,13 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
     func test${Encoding.title()}EncodingWithUnicodeMessage() {
         let format = TextFormat(template: "%{message}", encoding: .${Encoding}, terminator: "")
 
-        guard let bytes = format.bytes(from: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext()),
-              let result = String(bytes: bytes, encoding: .${Encoding})
+        let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Print a few unicode characters ♡, 🌍, 🇵🇷, 🐌, 🐧, 🐪.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 100, threadIdentifier: 1100), staticContext: TestStaticContext())
+        let expected: String       = "${Expected}"
+
+        guard let bytes = format.bytes(from: input), let result = String(bytes: bytes, encoding: .${Encoding})
             else { XCTFail("Failed to convert log entry to encoding \".${Encoding}\""); return }
 
-        XCTAssertTrue(result.range(of: "${Expected}", options: [.regularExpression, .caseInsensitive]) != nil,
-            "Failed conversion to \".${Encoding}\".")
+        XCTAssertTrue(result.range(of: expected, options: [.regularExpression, .caseInsensitive]) != nil, "Failed conversion to \".${Encoding}\".")
     }
 % end
 }

--- a/Tests/TraceLogTests/TestWriters/CallbackTestWriter.swift
+++ b/Tests/TraceLogTests/TestWriters/CallbackTestWriter.swift
@@ -26,13 +26,13 @@ import TraceLog
 /// A Writer that when the log func is called, will execute your block of code passing you the values.
 ///
 class CallbackTestWriter: Writer {
-    let callback: (Double, LogLevel, String, String, RuntimeContext, StaticContext) -> Void
+    let callback: (Writer.LogEntry) -> Void
 
-    init(callback: @escaping (Double, LogLevel, String, String, RuntimeContext, StaticContext) -> Void) {
+    init(callback: @escaping (Writer.LogEntry) -> Void) {
         self.callback = callback
     }
 
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
-        callback(timestamp, level, tag, message, runtimeContext, staticContext)
+    func write(_ entry: Writer.LogEntry) {
+        callback(entry)
     }
 }

--- a/Tests/TraceLogTests/TestWriters/FailWhenFiredTestWriter.swift
+++ b/Tests/TraceLogTests/TestWriters/FailWhenFiredTestWriter.swift
@@ -34,7 +34,7 @@ class FailWhenFiredWriter: Writer {
         self.semaphore = semaphore
     }
 
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    func write(_ entry: Writer.LogEntry) {
         semaphore.signal()
     }
 }

--- a/Tests/TraceLogTests/TestWriters/SleepyTestWriter.swift
+++ b/Tests/TraceLogTests/TestWriters/SleepyTestWriter.swift
@@ -32,7 +32,7 @@ class SleepyTestWriter: Writer {
         self.sleepTime = sleepTime
     }
 
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    func write(_ entry: Writer.LogEntry) {
         usleep(sleepTime)
     }
 }

--- a/Tests/TraceLogTests/TestWriters/ValidateExpectedValuesTestWriter.swift
+++ b/Tests/TraceLogTests/TestWriters/ValidateExpectedValuesTestWriter.swift
@@ -46,15 +46,15 @@ class ValidateExpectedValuesTestWriter: Writer {
         self.testFileFunction = testFileFunction
     }
 
-    func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {
+    func write(_ entry: Writer.LogEntry) {
 
-        if level == self.level &&
-            tag == self.tag &&
-            message == self.message {
+        if entry.level == self.level &&
+           entry.tag == self.tag &&
+           entry.message == self.message {
 
             if !testFileFunction ||
-                staticContext.file == self.file &&
-                staticContext.function == self.function {
+                entry.staticContext.file == self.file &&
+                entry.staticContext.function == self.function {
                 expectation.fulfill()
             }
         }

--- a/Tests/TraceLogTests/TraceLogPerformanceTests.swift
+++ b/Tests/TraceLogTests/TraceLogPerformanceTests.swift
@@ -14,7 +14,7 @@ private let testIterations = 1000
 class TraceLogPerformanceTestsSwift: XCTestCase {
 
     struct NullWriter: Writer {
-        func log(_ timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) {}
+        func write(_ entry: Writer.LogEntry) {}
     }
 
     func testLogErrorPerformance_NullWriter() {

--- a/Tests/TraceLogTests/Writers/ConsoleWriterTests.swift
+++ b/Tests/TraceLogTests/Writers/ConsoleWriterTests.swift
@@ -24,7 +24,7 @@ import TraceLogTestHarness
 
 private let testDirectory = "ConsoleWriterTestsTmp"
 
-private let testEqual: (ConsoleWriter, LogEntry?, LogEntry) -> Void = { writer, result, expected in
+private let testEqual: (ConsoleWriter, TestLogEntry?, TestLogEntry) -> Void = { writer, result, expected in
 
     guard let result = result
         else { XCTFail("Failed to locate log entry."); return }
@@ -146,7 +146,7 @@ private class ConsoleWriterReader: Reader {
         self.directory = directory
     }
 
-    func logEntry(for writer: ConsoleWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> LogEntry? {
+    func logEntry(for writer: ConsoleWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> TestLogEntry? {
 
         do {
             ///
@@ -235,7 +235,7 @@ private class ConsoleWriterReader: Reader {
                 return String(entry[range]).replacingOccurrences(of: "\n", with: "")
             }()
 
-            return LogEntry(timestamp: timestamp,
+            return TestLogEntry(timestamp: timestamp,
                             level: level,
                             message: message,
                             tag: tag,

--- a/Tests/TraceLogTests/Writers/FileWriterTests.swift
+++ b/Tests/TraceLogTests/Writers/FileWriterTests.swift
@@ -24,7 +24,7 @@ import TraceLogTestHarness
 
 private let testDirectory = "FileWriterTestsTmp"
 
-private let testEqual: (FileWriter, LogEntry?, LogEntry) -> Void = { writer, result, expected in
+private let testEqual: (FileWriter, TestLogEntry?, TestLogEntry) -> Void = { writer, result, expected in
 
     guard let result = result
         else { XCTFail("Failed to locate log entry."); return }
@@ -304,7 +304,7 @@ private class FileReader: Reader {
         self.directory = directory
     }
 
-    func logEntry(for writer: FileWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> LogEntry? {
+    func logEntry(for writer: FileWriter, timestamp: Double, level: LogLevel, tag: String, message: String, runtimeContext: RuntimeContext, staticContext: StaticContext) -> TestLogEntry? {
 
         do {
             let url = URL(fileURLWithPath: self.directory).appendingPathComponent(fileName)
@@ -385,7 +385,7 @@ private class FileReader: Reader {
                         return String(entry[range]).replacingOccurrences(of: "\n", with: "")
                     }()
 
-                    return LogEntry(timestamp: timestamp,
+                    return TestLogEntry(timestamp: timestamp,
                                     level: level,
                                     message: message,
                                     tag: tag,


### PR DESCRIPTION
- Added `LogEntry` tuple type to `Writer` defining the formal types that a Writer writes.
- Changed `Writer` protocol `log(timestamp:level:tag:message:runtimeContext:staticContext:)` method to `write(_ entry: Writer.LogEntry)` to make it easier to process messages by writers and formatters.