### PR TITLE
Change OutputStreamFormatter.bytes return value to Swift.Result.

### DIFF
--- a/Sources/TraceLog/Formatters/JSONFormat.swift
+++ b/Sources/TraceLog/Formatters/JSONFormat.swift
@@ -116,7 +116,7 @@ public struct JSONFormat: OutputStreamFormatter {
 
     /// Text conversion function required by the `OutputStreamFormatter` protocol.
     ///
-    public func bytes(from entry: Writer.LogEntry) -> [UInt8]? {
+    public func bytes(from entry: Writer.LogEntry) -> Result<[UInt8], OutputStreamFormatterError> {
         var text = String()
 
         text.write("{\(conditional.newLine)")
@@ -144,7 +144,7 @@ public struct JSONFormat: OutputStreamFormatter {
         /// JSON text exchanged between systems that are not part of a closed
         /// ecosystem MUST be encoded using UTF-8 [RFC3629].
         ///
-        return Array(text.utf8)
+        return .success(Array(text.utf8))
     }
 
     /// Generic type emitter

--- a/Sources/TraceLog/Formatters/OutputStreamFormatter.swift
+++ b/Sources/TraceLog/Formatters/OutputStreamFormatter.swift
@@ -19,6 +19,10 @@
 ///
 import Foundation
 
+public enum OutputStreamFormatterError: Error {
+    case encodingFailure(String)
+}
+
 /// A formatter type for formating the output of a `Writer` type.
 ///
 public protocol OutputStreamFormatter {
@@ -26,5 +30,5 @@ public protocol OutputStreamFormatter {
     /// Accepts traceLogs standard LogEntry and outputs an Array of bytes
     /// containing the formatted output.
     ///
-    func bytes(from entry: Writer.LogEntry) -> [UInt8]?
+    func bytes(from entry: Writer.LogEntry) -> Result<[UInt8], OutputStreamFormatterError>
 }

--- a/Sources/TraceLog/Formatters/TextFormat.swift
+++ b/Sources/TraceLog/Formatters/TextFormat.swift
@@ -277,7 +277,7 @@ public struct TextFormat: OutputStreamFormatter {
 
     /// Text conversion function required by the `OutputStreamFormatter` protocol.
     ///
-    public func bytes(from entry: Writer.LogEntry) -> [UInt8]? {
+    public func bytes(from entry: Writer.LogEntry) -> Result<[UInt8], OutputStreamFormatterError> {
         var text = String()
 
         /// Write all the elements that have been pre-calculated
@@ -314,9 +314,9 @@ public struct TextFormat: OutputStreamFormatter {
         /// still be printed minus the un-encodable characters.
         ///
         guard let data = text.data(using: self.encoding, allowLossyConversion: true)
-            else { return nil }
+            else { return .failure(.encodingFailure("Failed to encode entry using \(self.encoding) encoding.")) }
 
-        return Array(data)
+        return .success(Array(data))
     }
 
     /// Generic type writer

--- a/Sources/TraceLog/Writers/ConsoleWriter.swift
+++ b/Sources/TraceLog/Writers/ConsoleWriter.swift
@@ -54,7 +54,7 @@ public class ConsoleWriter: OutputStreamWriter {
     ///
     public func write(_ entry: Writer.LogEntry) {
 
-        guard let bytes = format.bytes(from: entry)
+        guard case .success(let bytes) = format.bytes(from: entry)
             else { return }
 
         ///

--- a/Sources/TraceLog/Writers/FileWriter.swift
+++ b/Sources/TraceLog/Writers/FileWriter.swift
@@ -108,7 +108,7 @@ public class FileWriter: OutputStreamWriter {
     ///
     public func write(_ entry: Writer.LogEntry) {
 
-        guard let bytes = format.bytes(from: entry)
+        guard case .success(let bytes) = format.bytes(from: entry)
             else { return }
 
         /// Note: Since we could be called on any thread in TraceLog direct mode

--- a/Tests/TraceLogTests/Formatters/JSONFormatTests.swift
+++ b/Tests/TraceLogTests/Formatters/JSONFormatTests.swift
@@ -93,7 +93,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.timestamp], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"timestamp\":28800.0}")
@@ -106,7 +106,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.timestamp], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"timestamp\" : 28800.0\n}")
@@ -120,7 +120,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.level], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"level\":\"INFO\"}")
@@ -133,7 +133,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.level], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"level\" : \"INFO\"\n}")
@@ -147,7 +147,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.tag], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"tag\":\"TestTag\"}")
@@ -160,7 +160,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.tag], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"tag\" : \"TestTag\"\n}")
@@ -174,7 +174,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.message], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"message\":\"Test message.\"}")
@@ -187,7 +187,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.message], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"message\" : \"Test message.\"\n}")
@@ -201,7 +201,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processName], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processName\":\"TestProcess\"}")
@@ -214,7 +214,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess"), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processName], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processName\" : \"TestProcess\"\n}")
@@ -228,7 +228,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processIdentifier\":120}")
@@ -241,7 +241,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processIdentifier\" : 120\n}")
@@ -255,7 +255,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"processIdentifier\":120}")
@@ -268,7 +268,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 120), staticContext: TestStaticContext())
         let format = JSONFormat(attributes: [.processIdentifier], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"processIdentifier\" : 120\n}")
@@ -282,7 +282,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
         let format = JSONFormat(attributes: [.file], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"file\":\"JSONFormat.swift\"}")
@@ -295,7 +295,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "JSONFormat.swift"))
         let format = JSONFormat(attributes: [.file], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"file\" : \"JSONFormat.swift\"\n}")
@@ -309,7 +309,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
         let format = JSONFormat(attributes: [.function], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"function\":\"testAttributeFunction()\"}")
@@ -322,7 +322,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testAttributeFunction()"))
         let format = JSONFormat(attributes: [.function], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"function\" : \"testAttributeFunction()\"\n}")
@@ -336,7 +336,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
         let format = JSONFormat(attributes: [.line], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"line\":240}")
@@ -349,7 +349,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 240))
         let format = JSONFormat(attributes: [.line], options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\n\t\"line\" : 240\n}")
@@ -359,7 +359,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
         let format = JSONFormat(terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         guard let json = try JSONSerialization.jsonObject(with: Data(bytes), options: []) as? [String: Any]
@@ -382,7 +382,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 120, threadIdentifier: 200), staticContext: TestStaticContext(file: "JSONFormatTests.swift", function: "testAttributeDefaultList()", line: 240))
         let format = JSONFormat( options: [.prettyPrint], terminator: "")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         guard let json = try JSONSerialization.jsonObject(with: Data(bytes), options: []) as? [String: Any]
@@ -410,7 +410,7 @@ class JSONFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let format = JSONFormat(attributes: [.message], terminator: ",\n\t")
 
-        guard let bytes =  format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail(); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), "{\"message\":\"Simple message.\"},\n\t")

--- a/Tests/TraceLogTests/Formatters/TextFormat+EncodingTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormat+EncodingTests.swift
@@ -35,7 +35,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .ascii, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".ascii\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .ascii), expected, "Failed conversion to \".ascii\".")
@@ -51,7 +51,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .iso2022JP, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".iso2022JP\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .iso2022JP), expected, "Failed conversion to \".iso2022JP\".")
@@ -67,7 +67,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .isoLatin1, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin1\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin1), expected, "Failed conversion to \".isoLatin1\".")
@@ -83,7 +83,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .isoLatin2, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin2\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .isoLatin2), expected, "Failed conversion to \".isoLatin2\".")
@@ -99,7 +99,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .macOSRoman, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".macOSRoman\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .macOSRoman), expected, "Failed conversion to \".macOSRoman\".")
@@ -115,7 +115,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .nextstep, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".nextstep\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .nextstep), expected, "Failed conversion to \".nextstep\".")
@@ -131,7 +131,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .nonLossyASCII, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".nonLossyASCII\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .nonLossyASCII), expected, "Failed conversion to \".nonLossyASCII\".")
@@ -147,7 +147,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .shiftJIS, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".shiftJIS\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .shiftJIS), expected, "Failed conversion to \".shiftJIS\".")
@@ -163,7 +163,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .unicode, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".unicode\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .unicode), expected, "Failed conversion to \".unicode\".")
@@ -179,7 +179,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf16), expected, "Failed conversion to \".utf16\".")
@@ -195,7 +195,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16BigEndian\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf16BigEndian), expected, "Failed conversion to \".utf16BigEndian\".")
@@ -211,7 +211,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf16LittleEndian\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf16LittleEndian), expected, "Failed conversion to \".utf16LittleEndian\".")
@@ -227,7 +227,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf32), expected, "Failed conversion to \".utf32\".")
@@ -243,7 +243,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32BigEndian\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf32BigEndian), expected, "Failed conversion to \".utf32BigEndian\".")
@@ -259,7 +259,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf32LittleEndian\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf32LittleEndian), expected, "Failed conversion to \".utf32LittleEndian\".")
@@ -275,7 +275,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".utf8\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion to \".utf8\".")
@@ -291,7 +291,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1250, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1250\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1250), expected, "Failed conversion to \".windowsCP1250\".")
@@ -307,7 +307,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1251, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1251\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1251), expected, "Failed conversion to \".windowsCP1251\".")
@@ -323,7 +323,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1252, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1252\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1252), expected, "Failed conversion to \".windowsCP1252\".")
@@ -339,7 +339,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1253, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1253\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1253), expected, "Failed conversion to \".windowsCP1253\".")
@@ -355,7 +355,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1254, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1254\""); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .windowsCP1254), expected, "Failed conversion to \".windowsCP1254\".")
@@ -372,7 +372,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .ascii, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .ascii)
             else { XCTFail("Failed to convert log entry to encoding \".ascii\""); return }
 
@@ -389,7 +389,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .iso2022JP, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .iso2022JP)
             else { XCTFail("Failed to convert log entry to encoding \".iso2022JP\""); return }
 
@@ -406,7 +406,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .isoLatin1, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .isoLatin1)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin1\""); return }
 
@@ -423,7 +423,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .isoLatin2, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .isoLatin2)
             else { XCTFail("Failed to convert log entry to encoding \".isoLatin2\""); return }
 
@@ -440,7 +440,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .macOSRoman, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .macOSRoman)
             else { XCTFail("Failed to convert log entry to encoding \".macOSRoman\""); return }
 
@@ -457,7 +457,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .nextstep, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .nextstep)
             else { XCTFail("Failed to convert log entry to encoding \".nextstep\""); return }
 
@@ -474,7 +474,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .nonLossyASCII, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .nonLossyASCII)
             else { XCTFail("Failed to convert log entry to encoding \".nonLossyASCII\""); return }
 
@@ -491,7 +491,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .shiftJIS, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .shiftJIS)
             else { XCTFail("Failed to convert log entry to encoding \".shiftJIS\""); return }
 
@@ -508,7 +508,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .unicode, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .unicode)
             else { XCTFail("Failed to convert log entry to encoding \".unicode\""); return }
 
@@ -525,7 +525,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16)
             else { XCTFail("Failed to convert log entry to encoding \".utf16\""); return }
 
@@ -542,7 +542,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16BigEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf16BigEndian\""); return }
 
@@ -559,7 +559,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf16LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf16LittleEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf16LittleEndian\""); return }
 
@@ -576,7 +576,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32)
             else { XCTFail("Failed to convert log entry to encoding \".utf32\""); return }
 
@@ -593,7 +593,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32BigEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32BigEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf32BigEndian\""); return }
 
@@ -610,7 +610,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf32LittleEndian, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf32LittleEndian)
             else { XCTFail("Failed to convert log entry to encoding \".utf32LittleEndian\""); return }
 
@@ -627,7 +627,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .utf8)
             else { XCTFail("Failed to convert log entry to encoding \".utf8\""); return }
 
@@ -644,7 +644,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1250, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1250)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1250\""); return }
 
@@ -661,7 +661,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1251, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1251)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1251\""); return }
 
@@ -678,7 +678,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1252, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1252)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1252\""); return }
 
@@ -695,7 +695,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1253, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1253)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1253\""); return }
 
@@ -712,7 +712,7 @@ class TextFormatEncodingWithUnicodeTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .windowsCP1254, terminator: "")
 
-        guard let bytes = format.bytes(from: entry),
+        guard case .success(let bytes) = format.bytes(from: entry),
               let result = String(bytes: bytes, encoding: .windowsCP1254)
             else { XCTFail("Failed to convert log entry to encoding \".windowsCP1254\""); return }
 

--- a/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormat+InternationalLanguagesTests.swift
@@ -38,7 +38,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Danish language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Danish\".")
@@ -52,7 +52,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the German language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"German\".")
@@ -66,7 +66,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Greek language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Greek\".")
@@ -80,7 +80,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the English language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"English\".")
@@ -94,7 +94,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Spanish language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Spanish\".")
@@ -108,7 +108,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the French language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"French\".")
@@ -122,7 +122,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the IrishGaelic language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"IrishGaelic\".")
@@ -136,7 +136,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Hungarian language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Hungarian\".")
@@ -150,7 +150,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Icelandic language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Icelandic\".")
@@ -164,7 +164,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Japanese language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Japanese\".")
@@ -178,7 +178,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Katakana language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Katakana\".")
@@ -192,7 +192,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Polish language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Polish\".")
@@ -206,7 +206,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Russian language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Russian\".")
@@ -220,7 +220,7 @@ class TextFormatInternationalLanguagesTests: XCTestCase {
 
         let format = TextFormat(template: "%{message}", encoding: .utf8, terminator: "")
 
-        guard let bytes = format.bytes(from: input)
+        guard case .success(let bytes) = format.bytes(from: input)
             else { XCTFail("Failed to convert log entry for the Turkish language."); return }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected, "Failed conversion for \"Turkish\".")

--- a/Tests/TraceLogTests/Formatters/TextFormatTests.swift
+++ b/Tests/TraceLogTests/Formatters/TextFormatTests.swift
@@ -141,8 +141,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -155,8 +155,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = String(repeating: TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp)), count: 3)
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -171,8 +171,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "28800.0"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -185,8 +185,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "28800.028800.028800.0"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -201,8 +201,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "INFO"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -215,8 +215,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "INFOINFOINFO"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -231,8 +231,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "TestTag"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -245,8 +245,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "TestTagTestTagTestTag"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -261,8 +261,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "Test message."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -275,8 +275,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "Test message.Test message.Test message."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -291,8 +291,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
         let expected: String       = "Test Process"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -305,8 +305,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "Test Process"), staticContext: TestStaticContext())
         let expected: String       = "Test ProcessTest ProcessTest Process"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -321,8 +321,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
         let expected: String       = "500"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -335,8 +335,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processIdentifier: 500), staticContext: TestStaticContext())
         let expected: String       = "500500500"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -351,8 +351,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
         let expected: String       = "200"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -365,8 +365,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(threadIdentifier: 200), staticContext: TestStaticContext())
         let expected: String       = "200200200"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -381,8 +381,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
         let expected: String       = "TextFormatTests.swift"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -395,8 +395,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(file: "TextFormatTests.swift"))
         let expected: String       = "TextFormatTests.swiftTextFormatTests.swiftTextFormatTests.swift"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -411,8 +411,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
         let expected: String       = "testTemplateFunction()"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -425,8 +425,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(function: "testTemplateFunction()"))
         let expected: String       = "testTemplateFunction()testTemplateFunction()testTemplateFunction()"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -441,8 +441,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "120"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -455,8 +455,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "120120120"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -469,8 +469,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext())
         let expected: String       = "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))) TestProcess[100:1100] INFO: <TestTag> Test message."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -484,8 +484,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
         let expected: String       = "\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp))) \(input.timestamp) TestProcess[50:200] WARNING: <TestTag> [TextFormatTests.swift:testTemplateWithAllVariables():306] Test message."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -498,8 +498,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
         let expected: String       = "\"\(TextFormatTests.dateFormatter.string(from: Date(timeIntervalSince1970: input.timestamp)))\", \"TestProcess\", 50, 200, \"WARNING\", \"TestTag\", \"Test message.\"\n"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -513,8 +513,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 1.0, level: .warning, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(processName: "TestProcess", processIdentifier: 50, threadIdentifier: 200), staticContext: TestStaticContext(file: "TextFormatTests.swift", function: "testTemplateWithAllVariables()", line: 306))
         let expected: String       = "~!@#$%^&*()WARNING1234567890TestTagabcdefghijklmnop"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -530,8 +530,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "{}} This is a constant string that will be output %{(0001234 with special characters}."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -545,8 +545,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "%{This} %{is} %{a} %{constant} %{string} %{that} %{will} %{be} %{output}"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -559,8 +559,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Test message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "%{INFO}"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -573,8 +573,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "INFO %{level}"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -587,8 +587,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{level}", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "%{level} INFO"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -601,8 +601,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "%{message} check", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "%{message} check"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -619,8 +619,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "This message contains multiple lines and control characters."
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -635,8 +635,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "\\tThis message contains multiple \\nlines and \\tcontrol characters.\\n"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -651,8 +651,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "\tThis message contains multiple \nlines and \tcontrol characters.\n", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "\tThis message contains multiple \nlines and \tcontrol characters.\n"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }
@@ -668,8 +668,8 @@ class TextFormatTests: XCTestCase {
         let input: Writer.LogEntry = (timestamp: 28800.0, level: .info, tag: "TestTag", message: "Simple message.", runtimeContext: TestRuntimeContext(), staticContext: TestStaticContext(line: 120))
         let expected: String       = "Simple message.,\n\t"
 
-        guard let bytes = format.bytes(from: input)
-            else { XCTFail(); return }
+        guard case .success(let bytes) = format.bytes(from: input)
+            else { XCTFail(); return  }
 
         XCTAssertEqual(String(bytes: bytes, encoding: .utf8), expected)
     }


### PR DESCRIPTION
- Added OutputStreamFormatterError.
- Change OutputStreamFormatter.bytes return value to Swift.Result<[UInt8], OutputStreamFormatterError>.
