### PR TITLE
Fix 'Initialization of 'UnsafePointer<UInt8>' results in a dangling pointer' warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   include:
     -
       os: linux
-      dist: trusty
+      dist: bionic
       sudo: required
       env:
          - BUILD="cmake build"
@@ -23,7 +23,7 @@ matrix:
          - BUILD="cmake build"
     -
       os: linux
-      dist: trusty
+      dist: bionic
       sudo: required
       env:
          - BUILD="swift build"
@@ -103,9 +103,9 @@ before_install:
       sudo apt-get update -y
       sudo apt-get -y install clang-3.8 lldb-3.8 libicu-dev
 
-      wget https://swift.org/builds/swift-5.0-branch/ubuntu1404/swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-28-a/swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-28-a-ubuntu14.04.tar.gz
-      tar xzvf swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-28-a-ubuntu14.04.tar.gz
-      export PATH=$(pwd)/swift-5.0-DEVELOPMENT-SNAPSHOT-2018-12-28-a-ubuntu14.04/usr/bin:$PATH
+      wget https://swift.org/builds/swift-5.0-release/ubuntu1804/swift-5.0-RELEASE/swift-5.0-RELEASE-ubuntu18.04.tar.gz
+      tar xzvf swift-5.0-RELEASE-ubuntu18.04.tar.gz
+      export PATH=$(pwd)/swift-5.0-RELEASE-ubuntu18.04/usr/bin:$PATH
     fi
 
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All significant changes to this project will be documented in this file.
 
+## [5.0.1](https://github.com/tonystone/tracelog/tree/5.0.1)
+
+#### Fixed
+- Fix 'Initialization of 'UnsafePointer<UInt8>' results in a dangling pointer' compiler warning.
+
 ## [5.0.0](https://github.com/tonystone/tracelog/tree/5.0.0)
 
 #### Added

--- a/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
+++ b/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
@@ -84,7 +84,7 @@ extension RawOutputStream: OutputStream {
     func write(_ bytes: [UInt8]) -> Result<Int, OutputStreamError> {
 
         return bytes.withUnsafeBytes { (bufferPointer) -> Result<Int, OutputStreamError> in
-            
+
             guard var buffer = bufferPointer.baseAddress
                 else { return .failure(.invalidArgument("byte buffer empty, can not write.")) }
 
@@ -110,7 +110,6 @@ extension RawOutputStream: OutputStream {
                 /// we wrote zero bytes (written != 0)
                 ///
             } while (length != 0 && written != 0)
-
 
             return .success(written)
         }

--- a/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
+++ b/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
@@ -84,6 +84,7 @@ extension RawOutputStream: OutputStream {
     func write(_ bytes: [UInt8]) -> Result<Int, OutputStreamError> {
 
         return bytes.withUnsafeBytes { (bufferPointer) -> Result<Int, OutputStreamError> in
+            
             guard var buffer = bufferPointer.baseAddress
                 else { return .failure(.invalidArgument("byte buffer empty, can not write.")) }
 

--- a/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
+++ b/Sources/TraceLog/Internal/Utilities/Streams/RawOutputStream.swift
@@ -83,31 +83,36 @@ extension RawOutputStream: OutputStream {
     ///
     func write(_ bytes: [UInt8]) -> Result<Int, OutputStreamError> {
 
-        var buffer = UnsafePointer(bytes)
-        var length = bytes.count
+        return bytes.withUnsafeBytes { (bufferPointer) -> Result<Int, OutputStreamError> in
+            guard var buffer = bufferPointer.baseAddress
+                else { return .failure(.invalidArgument("byte buffer empty, can not write.")) }
 
-        var written: Int = 0
+            var length = bufferPointer.count
 
-        /// Handle partial writes.
-        ///
-        repeat {
-            written = self.write(self.fd, buffer, length)
+            var written: Int = 0
 
-            if written == -1 {
-                if errno == EINTR { /// Always retry if interrupted.
-                    continue
-                }
-                return .failure(OutputStreamError.error(for: errno))
-            }
-            length -= written
-            buffer += written
-
-            /// Exit if there are no more bytes (length != 0) or
-            /// we wrote zero bytes (written != 0)
+            /// Handle partial writes.
             ///
-        } while (length != 0 && written != 0)
+            repeat {
+                written = self.write(self.fd, buffer, length)
 
-        return .success(written)
+                if written == -1 {
+                    if errno == EINTR { /// Always retry if interrupted.
+                        continue
+                    }
+                    return .failure(OutputStreamError.error(for: errno))
+                }
+                length -= written
+                buffer += written
+
+                /// Exit if there are no more bytes (length != 0) or
+                /// we wrote zero bytes (written != 0)
+                ///
+            } while (length != 0 && written != 0)
+
+
+            return .success(written)
+        }
     }
 }
 
@@ -116,7 +121,7 @@ extension RawOutputStream: OutputStream {
 internal extension RawOutputStream {
 
     @inline(__always)
-    func write(_ fd: Int32, _ buffer: UnsafePointer<UInt8>, _ nbytes: Int) -> Int {
+    func write(_ fd: Int32, _ buffer: UnsafeRawPointer, _ nbytes: Int) -> Int {
         #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             return Darwin.write(fd, buffer, nbytes)
         #elseif os(Linux) || CYGWIN

--- a/TraceLog.podspec
+++ b/TraceLog.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "TraceLog"
-  s.version          = "5.0.0"
+  s.version          = "5.0.1"
   s.summary          = "Dead Simple: logging the way it's meant to be!"
   s.description      = <<-DESC
                              TraceLog is a configurable debug logging system.  It is unique in that it's configured


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix new xcode warning 'Initialization of 'UnsafePointer<UInt8>' results in a dangling pointer'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
All existing tests have been run and have passed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced
     in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Avoid other runtime dependencies
- [x] Have you written or updated unit tests to verify your changes?
- [x] Have you ensured that the full suite of tests is executed via `make tests` in the cmake-build-debug` directory off the root of the project?
- [x] If applicable, have you updated the documentation?
- [x] If applicable, have you updated the [CHANGELOG.md](https://github.com/tonystone/tracelog/blob/master/CHANGELOG.md) file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
