### PR TITLE
Buffer writer fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All significant changes to this project will be documented in this file.
 
 #### Fixed
 - Fix 'Initialization of 'UnsafePointer<UInt8>' results in a dangling pointer' compiler warning.
+- Fixed crash in AsyncWriterProxy buffering when buffer is empty.
 
 ## [5.0.0](https://github.com/tonystone/tracelog/tree/5.0.0)
 

--- a/Sources/TraceLog/Internal/Proxies/AsyncWriterProxy.swift
+++ b/Sources/TraceLog/Internal/Proxies/AsyncWriterProxy.swift
@@ -109,7 +109,7 @@ internal class AsyncWriterProxy: WriterProxy {
         /// If the writer is available, read and log all message
         /// (in order) from the buffer.
         ///
-        for _ in 1...buffer.queue.count {
+        for _ in 0..<buffer.queue.count {
             let entry = buffer.queue.peek()
 
             switch self.writer.write(entry) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing a crash when buffering is on and the buffer is empty when it attempts to write.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This fix is currently being tested in a pre-release application during the QA cycle.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### For all changes:
- [ ] Is there an issue associated with this PR? Is it referenced
     in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically master)?
- [ ] Is your initial contribution a single, squashed commit?

### For code changes:
- [x] Avoid other runtime dependencies
- [ ] Have you written or updated unit tests to verify your changes?
- [x] Have you ensured that the full suite of tests is executed via `make tests` in the cmake-build-debug` directory off the root of the project?
- [x] If applicable, have you updated the documentation?
- [x] If applicable, have you updated the [CHANGELOG.md](https://github.com/tonystone/tracelog/blob/master/CHANGELOG.md) file?

### For documentation related changes:
- [ ] Have you ensured that format looks appropriate for the output in which it is rendered?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and submit an update to your PR as soon as possible.
